### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Honggfuzz working directory, defaults to `hfuzz_workspace`.
 
 Honggfuzz input files (also called "corpus"), defaults to `$HFUZZ_WORKSPACE/{TARGET}/input`.
 
-## Conditionnal compilation
+## Conditional compilation
 
 Sometimes, it is necessary to make some specific adaptation to your code to yield a better fuzzing efficiency.
 


### PR DESCRIPTION
I thought maybe this was an intentional subtle joke, mimicking the two "g"s and "z"s in honggfuzz, but probably not.