### PR TITLE
Cleanup output if version mismatch.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,5 @@
 use std::env;
-use std::process::Command;
+use std::process::{self, Command};
 
 const VERSION: &'static str = env!("CARGO_PKG_VERSION");
 
@@ -21,9 +21,11 @@ fn main() {
 
     // check that "cargo hfuzz" command is at the same version as this file
     let honggfuzz_build_version = env::var("CARGO_HONGGFUZZ_BUILD_VERSION").unwrap_or("unknown".to_string());
-    assert!(VERSION == honggfuzz_build_version,
-            "hongfuzz dependency ({}) and build command ({}) versions do not match",
-            VERSION, honggfuzz_build_version);
+    if VERSION != honggfuzz_build_version {
+        eprintln!("hongfuzz dependency ({}) and build command ({}) versions do not match",
+                  VERSION, honggfuzz_build_version);
+        process::exit(1);
+    }
 
     let out_dir = env::var("OUT_DIR").unwrap(); // from cargo
     let crate_root = env::var("CRATE_ROOT").unwrap(); //from honggfuzz


### PR DESCRIPTION
If there's a version mismatch, this is what is outputted:

```
process didn't exit successfully: `/Users/corey/dev/targets/fuzzer-honggfuzz/hfuzz_target/release/build/honggfuzz-32eedb7c8be2fdad/build-script-build` (exit code: 101)
--- stderr
thread 'main' panicked at 'hongfuzz dependency (0.5.19) and build command (0.5.7) versions do not match', /Users/corey/.cargo/registry/src/github.com-1ecc6299db9ec823/honggfuzz-0.5.19/build.rs:24:5
note: Run with `RUST_BACKTRACE=1` for a backtrace.
```

Seems like we can just print the error instead of doing the panic message dance.