### PR TITLE
Allow more closures

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ For instance:
 - Never ever call `std::process::exit()`.
 - Disable logging and other unnecessary functionnalities.
 - Try to avoid modifying global state when possible.
+- Do not set up your own panic hook when run with `cfg(fuzzing)`
 
 
 When building with `cargo hfuzz`, the argument `--cfg fuzzing` is passed to `rustc` to allow you to condition the compilation of thoses adaptations thanks to the `cfg` macro like so:

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -6,3 +6,6 @@ authors = ["Paul Grandperrin <paul.grandperrin@gmail.com>"]
 [dependencies]
 honggfuzz = {path = ".."}
 # arbitrary = "0.1"
+libc = "*"
+positioned-io = "*"
+tempfile = "*"

--- a/example/src/bin/tempfile-closure.rs
+++ b/example/src/bin/tempfile-closure.rs
@@ -1,0 +1,38 @@
+extern crate honggfuzz;
+
+extern crate libc;
+extern crate positioned_io;
+extern crate tempfile;
+
+use positioned_io::WriteAt;
+use std::fs::File;
+use std::io::prelude::*;
+use std::io::SeekFrom;
+use std::os::unix::io::AsRawFd;
+
+
+fn main() {
+    let mut df: File = tempfile::tempfile().unwrap();
+    loop {
+        honggfuzz::fuzz(|data: &[u8]| {
+            let err = unsafe {
+                libc::ftruncate(df.as_raw_fd(), 0)
+            };
+            assert!(err == 0, "Failed to truncate");
+            df.write_all_at(0, data).expect("Failed to write");
+            df.seek(SeekFrom::Start(0)).expect("Failed to seek");
+            let mut data = Vec::new();
+            df.read_to_end(&mut data)
+                .expect("Failed to read");
+            if data.len() != 6 {return}
+            if data[0] != b'q' {return}
+            if data[1] != b'w' {return}
+            if data[2] != b'e' {return}
+            if data[3] != b'r' {return}
+            if data[4] != b't' {return}
+            if data[5] != b'y' {return}
+            panic!("BOOM")
+        });
+    }
+}
+

--- a/example/test.sh
+++ b/example/test.sh
@@ -82,7 +82,7 @@ RUSTFLAGS="" cargo build
 
 # but when we run it, it should fail with a useful error message and status 17
 set +e
-RUSTFLAGS="" cargo run
+RUSTFLAGS="" cargo run --bin example
 status=$?
 set -e
 test $status -eq 17

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,7 +249,7 @@ lazy_static! {
 }
 
 #[cfg(all(fuzzing, not(fuzzing_debug)))]
-pub fn fuzz<F>(closure: F) where F: FnOnce(&[u8]) + std::panic::UnwindSafe {
+pub fn fuzz<F>(closure: F) where F: FnOnce(&[u8]) {
     // sets panic hook if not already done
     lazy_static::initialize(&PANIC_HOOK);
 
@@ -262,19 +262,7 @@ pub fn fuzz<F>(closure: F) where F: FnOnce(&[u8]) + std::panic::UnwindSafe {
         buf = ::std::slice::from_raw_parts(buf_ptr, len_ptr);
     }
 
-    // We still catch unwinding panics just in case the fuzzed code modifies
-    // the panic hook.
-    // If so, the fuzzer will be unable to tell different bugs appart and you will
-    // only be able to find one bug at a time before fixing it to then find a new one.
-    let did_panic = std::panic::catch_unwind(|| {
-        closure(buf);
-    }).is_err();
-
-    if did_panic {
-        // hopefully the custom panic hook will be called before and abort the
-        // process before the stack frames are unwinded.
-        std::process::abort();
-    }
+    closure(buf);
 }
 
 #[cfg(all(fuzzing, fuzzing_debug))]


### PR DESCRIPTION
This allows passing closures that are not unwind-safe.
For example, closures that capture mutable references are now allowed.