### PR TITLE
Adjust for changed error types in arbitrary crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,9 @@ exclude = [
 travis-ci = { repository = "rust-fuzz/honggfuzz-rs", branch = "master" }
 maintenance = { status = "actively-developed" }
 
+[dependencies]
+arbitrary = "0.2"
+
 [dev-dependencies]
 rand = "0.5"
 


### PR DESCRIPTION
The current version 0.2 of the arbitrary crate seems to have changed
some error types so that the current code that is generated by the fuzz!
macro does not compile.

This changes the code to be independent of the errors types and also
adds arbitrary as a re-exported dependency so that its usage is fully
transparent to users of this crate.