### PR TITLE
Added build-grcov command

### DIFF
--- a/src/bin/cargo-hfuzz.rs
+++ b/src/bin/cargo-hfuzz.rs
@@ -222,7 +222,7 @@ fn hfuzz_build<T>(args: T, crate_root: &Path, build_type: &BuildType) where T: s
         .env("CARGO_TARGET_DIR", &honggfuzz_target) // change target_dir to not clash with regular builds
         .env("CRATE_ROOT", &crate_root);
     
-    if *build_type != BuildType::Debug {
+    if *build_type != BuildType::Debug && *build_type != BuildType::ProfileWithGrcov {
         command.arg("--release")
             .env("CARGO_HONGGFUZZ_BUILD_VERSION", VERSION)   // used by build.rs to check that versions are in sync
             .env("CARGO_HONGGFUZZ_TARGET_DIR", &honggfuzz_target); // env variable to be read by build.rs script 

--- a/src/bin/cargo-hfuzz.rs
+++ b/src/bin/cargo-hfuzz.rs
@@ -222,7 +222,11 @@ fn hfuzz_build<T>(args: T, crate_root: &Path, build_type: &BuildType) where T: s
         .env("CARGO_TARGET_DIR", &honggfuzz_target) // change target_dir to not clash with regular builds
         .env("CRATE_ROOT", &crate_root);
     
-    if *build_type != BuildType::Debug && *build_type != BuildType::ProfileWithGrcov {
+	if *build_type == BuildType::ProfileWithGrcov {
+		command.env("CARGO_HONGGFUZZ_BUILD_VERSION", VERSION)   // used by build.rs to check that versions are in sync
+            .env("CARGO_HONGGFUZZ_TARGET_DIR", &honggfuzz_target); // env variable to be read by build.rs script 
+    }                                                              // to place honggfuzz executable at a known location
+    else if *build_type != BuildType::Debug {
         command.arg("--release")
             .env("CARGO_HONGGFUZZ_BUILD_VERSION", VERSION)   // used by build.rs to check that versions are in sync
             .env("CARGO_HONGGFUZZ_TARGET_DIR", &honggfuzz_target); // env variable to be read by build.rs script 


### PR DESCRIPTION
This adds a `build-grcov` command described in https://github.com/rust-fuzz/honggfuzz-rs/issues/28.

Please note that this feature was hacked in a short time and there might be some better way to do that or there might be a better set of flags to get profiling.

I am happy to update this PR according to the comments.

This can also be further updated by e.g. adding a `run-grcov` which would run such built binary against all crashes and inputs and generate a zip with grcov profiling data (that can later be used to generate coverage report for given sources/package).