### PR TITLE
Fix compiler flags for ProfileWithGrcov build option

### DIFF
--- a/src/bin/cargo-hfuzz.rs
+++ b/src/bin/cargo-hfuzz.rs
@@ -162,7 +162,7 @@ fn hfuzz_build<T>(args: T, crate_root: &Path, build_type: &BuildType) where T: s
             rustflags.push_str("\
             --cfg fuzzing_debug \
             -Zprofile \
-            -Zno-landing-pads \
+            -Cpanic=abort \
             -C opt-level=0 \
             -C debuginfo=2 \
             -Ccodegen-units=1 \


### PR DESCRIPTION
This commit replaces the -Zno-landing-pads with the -C panic=unwind,
as the -Zno-landing-pdas is deprecated, see [here](https://github.com/rust-lang/rust/pull/70175).