### PR TITLE
remove linker hack

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   ubuntu-nightly:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1
@@ -25,7 +25,7 @@ jobs:
       run: ./test.sh
   
   ubuntu-beta:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1
@@ -39,7 +39,7 @@ jobs:
       run: ./test.sh
       
   ubuntu-stable:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "honggfuzz"
-version = "0.5.53"
+version = "0.5.54"
 edition = "2018"
 authors = ["Paul Grandperrin <paul.grandperrin@gmail.com>"]
 license = "MIT/Apache-2.0/Unlicense/WTFPL"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# honggfuzz-rs [![Build Status][travis-img]][travis] [![Crates.io][crates-img]][crates] [![Documentation][docs-img]][docs]
+# honggfuzz-rs [![Build Status][build-img]][build] [![Crates.io][crates-img]][crates] [![Documentation][docs-img]][docs]
 
-[travis-img]:   https://travis-ci.org/rust-fuzz/honggfuzz-rs.svg?branch=master
-[travis]:       https://travis-ci.org/rust-fuzz/honggfuzz-rs
+[build-img]:   https://github.com/rust-fuzz/honggfuzz-rs/actions/workflows/rust.yml/badge.svg
+[build]:       https://github.com/rust-fuzz/honggfuzz-rs/actions/workflows/rust.yml
 [crates-img]:   https://img.shields.io/crates/v/honggfuzz.svg
 [crates]:       https://crates.io/crates/honggfuzz
 [docs-img]:     https://docs.rs/honggfuzz/badge.svg

--- a/src/bin/cargo-hfuzz.rs
+++ b/src/bin/cargo-hfuzz.rs
@@ -129,19 +129,6 @@ fn hfuzz_run<T>(mut args: T, crate_root: &Path, build_type: &BuildType) where T:
 fn hfuzz_build<T>(args: T, crate_root: &Path, build_type: &BuildType) where T: std::iter::Iterator<Item=String> {
     let honggfuzz_target = env::var("CARGO_TARGET_DIR").unwrap_or_else(|_| HONGGFUZZ_TARGET.into());
 
-    // HACK: temporary fix, see https://github.com/rust-lang/rust/issues/53945#issuecomment-426824324
-    let use_gold_linker: bool = match Command::new("which") // check if the gold linker is available
-            .args(&["ld.gold"])
-            .status() {
-        Err(_) => false,
-        Ok(status) => {
-            match status.code() {
-                Some(0) => true,
-                _       => false
-            }
-        }
-    };
-
     let mut rustflags = "\
     --cfg fuzzing \
     -C debug-assertions \
@@ -193,11 +180,6 @@ fn hfuzz_build<T>(args: T, crate_root: &Path, build_type: &BuildType) where T: s
                     rustflags.push_str("\
                     -C llvm-args=-sanitizer-coverage-trace-compares \
                     ");
-                }
-
-                // HACK: temporary fix, see https://github.com/rust-lang/rust/issues/53945#issuecomment-426824324
-                if use_gold_linker {
-                    rustflags.push_str("-Clink-arg=-fuse-ld=gold ");
                 }
             }
         }


### PR DESCRIPTION
The hack causes troubles for projects utilizing `wasm32-unknown-unknown` targets as rust uses a custom linker [`wasm-lld`](https://github.com/rust-lang/rust/blob/d2b38d6b3c9d1ee52a360c3ce61e54b7aa91d405/src/doc/rustc/src/codegen-options/index.md#linker-flavor) for it.

I don't see any `__sancov_guards` errors when the hack is removed with the recent version of LLVM.

cc https://github.com/rust-lang/rust/issues/53945