### PR TITLE
refactor: use docopt, anyhow, fs-err, which crates to simplify and st…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 arbitrary = "1.0"
 rustc_version = "0.3.3"
+which = "4.1"
 
 [dev-dependencies]
 rand = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,12 +28,18 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 arbitrary = "1.0"
 rustc_version = "0.3.3"
+docopt = "1.1"
+serde = "1.0"
+anyhow = "1.0"
 fs-err = "2.5"
 which = "4.1"
+log = "0.4"
+pretty_env_logger = "0.4"
 
 [dev-dependencies]
 rand = "0.8"
 rand_chacha = "0.3"
+assert_matches = "1"
 
 [target.'cfg(fuzzing)'.dependencies]
 lazy_static = "1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 arbitrary = "1.0"
 rustc_version = "0.3.3"
+fs-err = "2.5"
 which = "4.1"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,8 @@ travis-ci = { repository = "rust-fuzz/honggfuzz-rs", branch = "master" }
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-arbitrary = "1"
+arbitrary = "1.0"
+rustc_version = "0.3.3"
 
 [dev-dependencies]
 rand = "0.8"

--- a/README.md
+++ b/README.md
@@ -192,7 +192,6 @@ For instance:
 * Try to avoid modifying global state when possible.
 * Do not set up your own panic hook when run with `cfg(fuzzing)`
 
-
 When building with `cargo hfuzz`, the argument `--cfg fuzzing` is passed to `rustc` to allow you to condition the compilation of thoses adaptations thanks to the `cfg` macro like so:
 
 ```rust

--- a/src/bin/cargo-hfuzz.rs
+++ b/src/bin/cargo-hfuzz.rs
@@ -1,8 +1,11 @@
+use anyhow::Result;
+use docopt::Docopt;
 use fs_err as fs;
+use serde::Deserialize;
 use std::env;
-use std::process::{self, Command};
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 const HONGGFUZZ_TARGET: &str = "hfuzz_target";
@@ -21,8 +24,8 @@ enum BuildType {
 
 
 #[inline(always)]
-fn target_triple() -> String {
-    rustc_version::version_meta().expect("RUSTC version data is available. qed").host
+fn target_triple() -> Result<String> {
+    Ok(rustc_version::version_meta()?.host)
 }
 
 fn find_crate_root() -> Result<PathBuf> {
@@ -75,24 +78,27 @@ fn hfuzz_run(args: Args, crate_root: &Path, build_type: BuildType) -> Result<()>
     let honggfuzz_workspace = env::var("HFUZZ_WORKSPACE").unwrap_or_else(|_| HONGGFUZZ_WORKSPACE.into());
     let honggfuzz_input = env::var("HFUZZ_INPUT").unwrap_or_else(|_| format!("{}/{}/input", honggfuzz_workspace, target));
 
-    hfuzz_build(vec!["--bin".to_string(), target.clone()].into_iter(), crate_root, build_type);
+    {
+        let mut args = args.clone();
+        let extra = vec!["--bin".to_owned(), target.clone()];
+        args.arg_sub = extra.into();
+        hfuzz_build(args, crate_root, build_type)?;
+    }
 
-    let triple = target_triple();
+    let triple = target_triple()?;
     match build_type {
         BuildType::Debug => {
-            let crash_filename = args.next().unwrap_or_else(||{
-                eprintln!("please specify the crash filename like this \"cargo hfuzz run-debug TARGET CRASH_FILENAME [ ARGS ... ]\"");
-                process::exit(1);
-            });
+            let crash_filename = args
+                .arg_crash_filename
+                .expect("Guaranteed by docopt meta desc. qed");
 
             let status = debugger_command(&target, &triple)
-                .args(args)
+                .args(args.arg_sub)
                 .env("CARGO_HONGGFUZZ_CRASH_FILENAME", crash_filename)
                 .env("RUST_BACKTRACE", env::var("RUST_BACKTRACE").unwrap_or_else(|_| "1".into()))
-                .status()
-                .unwrap();
+                .status()?;
             if !status.success() {
-                 process::exit(status.code().unwrap_or(1));
+                anyhow::bail!("Process did exit with code: {}", status.code().unwrap_or(1));
             }
         }
         _ => {
@@ -105,32 +111,54 @@ fn hfuzz_run(args: Args, crate_root: &Path, build_type: BuildType) -> Result<()>
 
             // get user-defined args for honggfuzz
             let hfuzz_run_args = env::var("HFUZZ_RUN_ARGS").unwrap_or_default();
+            log::debug!("HFUZZ_RUN_ARGS: {}", hfuzz_run_args);
 
             // FIXME: we split by whitespace without respecting escaping or quotes
             let hfuzz_run_args = hfuzz_run_args.split_whitespace();
 
-            fs::create_dir_all(&format!("{}/{}/input", &honggfuzz_workspace, target)).unwrap_or_else(|_| {
-                println!("error: failed to create \"{}/{}/input\"", &honggfuzz_workspace, target);
-            });
+            fs::create_dir_all(&format!("{}/{}/input", &honggfuzz_workspace, target))?;
 
             let command = format!("{}/honggfuzz", &honggfuzz_target);
-            Command::new(&command) // exec honggfuzz replacing current process
-                .args(&["-W", &format!("{}/{}", &honggfuzz_workspace, target), "-f", &honggfuzz_input, "-P"])
-                .args(hfuzz_run_args) // allows user-specified arguments to be given to honggfuzz
-                .args(&["--", &format!("{}/{}/release/{}", &honggfuzz_target, target_triple(), target)])
-                .args(args)
-                .env("ASAN_OPTIONS", asan_options)
-                .env("TSAN_OPTIONS", tsan_options)
-                .exec();
 
-            // code flow will only reach here if honggfuzz failed to execute
-            eprintln!("cannot execute {}, try to execute \"cargo hfuzz build\" from fuzzed project directory", &command);
-            process::exit(1);
+            let mut arguments = vec!["-W".to_owned(), format!("{}/{}", &honggfuzz_workspace, target), "-f".to_owned(), honggfuzz_input.to_owned(), "-P".to_owned()];
+            arguments.extend(hfuzz_run_args.map(ToString::to_string));
+            arguments.extend(args.arg_sub.into_iter());
+
+            // exec honggfuzz replacing current process
+            let mut cmd = Command::new(&command);
+            cmd
+                .env("ASAN_OPTIONS", asan_options)
+                .env("TSAN_OPTIONS", tsan_options);
+            if let Some(timeout) = args.flag_timeout {
+                arguments.extend(vec!["-t".to_owned(), timeout.to_string()]);
+            }
+            if let Some(n) = args.flag_iterations {
+                arguments.extend(vec!["-N".to_owned(), n.to_string()]);
+            }
+            if args.flag_quiet {
+                arguments.push("--quiet".to_owned());
+            }
+            if args.flag_verbose > 0 {
+                arguments.push("--verbose".to_owned());
+            }
+            if let Some(exitcode) = args.flag_exit_upon_crash {
+                arguments.push("--exit_upon_crash".to_owned());
+                arguments.push("--exit_code_upon_crash".to_owned());
+                arguments.push(exitcode.to_string());
+            }
+            arguments.extend(["--", &format!("{}/{}/release/{}", &honggfuzz_target, triple, target)].iter().map(ToString::to_string));
+
+            log::debug!("Exec: {} {}", &command, arguments.join(" "));
+
+            cmd.args(arguments).exec();
+
+            anyhow::bail!("Failed to execute {} \"cargo hfuzz build\" from fuzzed project directory", &command)
         }
     }
+    Ok(())
 }
 
-fn hfuzz_build<T>(args: T, crate_root: &Path, build_type: &BuildType) where T: std::iter::Iterator<Item=String> {
+fn hfuzz_build(args: Args, crate_root: &Path, build_type: BuildType) -> Result<()> {
     let honggfuzz_target = env::var("CARGO_TARGET_DIR").unwrap_or_else(|_| HONGGFUZZ_TARGET.into());
 
     let mut rustflags = "\
@@ -200,97 +228,293 @@ fn hfuzz_build<T>(args: T, crate_root: &Path, build_type: &BuildType) where T: s
 
     // get user-defined args for building
     let hfuzz_build_args = env::var("HFUZZ_BUILD_ARGS").unwrap_or_default();
+    log::debug!("HFUZZ_BUILD_ARGS: {}", hfuzz_build_args);
+
     // FIXME: we split by whitespace without respecting escaping or quotes
     let hfuzz_build_args = hfuzz_build_args.split_whitespace();
 
     let cargo_bin = env::var("CARGO").unwrap();
-    let mut command = Command::new(cargo_bin);
-    command.args(&["build", "--target", &target_triple()]) // HACK to avoid building build scripts with rustflags
-        .args(args)
-        .args(hfuzz_build_args) // allows user-specified arguments to be given to cargo build
+    let mut command = Command::new(&cargo_bin);
+    // HACK to avoid building build scripts with rustflags
+    let mut arguments = vec!["build".to_owned(), "--target".to_owned(), target_triple()?];
+    arguments.extend(hfuzz_build_args.map(ToString::to_string));
+    arguments.extend(args.arg_sub.iter().map(ToString::to_string));
+
+    log::debug!("Spawn: {} {}", &cargo_bin, arguments.join(" "));
+
+    command
         .env("RUSTFLAGS", rustflags)
         .env("CARGO_INCREMENTAL", cargo_incremental)
         .env("CARGO_TARGET_DIR", &honggfuzz_target) // change target_dir to not clash with regular builds
         .env("CRATE_ROOT", &crate_root);
 
-    if *build_type == BuildType::ProfileWithGrcov {
-        command.env("CARGO_HONGGFUZZ_BUILD_VERSION", VERSION)   // used by build.rs to check that versions are in sync
-            .env("CARGO_HONGGFUZZ_TARGET_DIR", &honggfuzz_target); // env variable to be read by build.rs script
-    }                                                              // to place honggfuzz executable at a known location
-    else if *build_type != BuildType::Debug {
-        command.arg("--release")
-            .env("CARGO_HONGGFUZZ_BUILD_VERSION", VERSION)   // used by build.rs to check that versions are in sync
-            .env("CARGO_HONGGFUZZ_TARGET_DIR", &honggfuzz_target); // env variable to be read by build.rs script
-    }                                                              // to place honggfuzz executable at a known location
-
-    let status = command.status().unwrap();
-    if !status.success() {
-         process::exit(status.code().unwrap_or(1));
+    // used by build.rs to check that versions are in sync
+    // env variable to be read by build.rs script
+    // to place honggfuzz executable at a known location
+    if build_type == BuildType::ProfileWithGrcov {
+        command
+            .env("CARGO_HONGGFUZZ_BUILD_VERSION", VERSION)
+            .env("CARGO_HONGGFUZZ_TARGET_DIR", &honggfuzz_target);
     }
+    else if build_type != BuildType::Debug {
+        command
+            .env("CARGO_HONGGFUZZ_BUILD_VERSION", VERSION)
+            .env("CARGO_HONGGFUZZ_TARGET_DIR", &honggfuzz_target);
+        arguments.push("--release".to_owned());
+    }
+
+    let status = command.args(arguments).status()?;
+    if !status.success() {
+        anyhow::bail!("Execution failed with status code {:?}", status.code());
+    }
+    Ok(())
 }
 
-fn hfuzz_clean<T>(args: T) where T: std::iter::Iterator<Item=String> {
+fn hfuzz_clean(args: Args) -> Result<()> {
     let honggfuzz_target = env::var("CARGO_TARGET_DIR").unwrap_or_else(|_| HONGGFUZZ_TARGET.into());
     let cargo_bin = env::var("CARGO").unwrap();
     let status = Command::new(cargo_bin)
         .args(&["clean"])
-        .args(args)
+        .args(args.arg_sub)
         .env("CARGO_TARGET_DIR", &honggfuzz_target) // change target_dir to not clash with regular builds
-        .status()
-        .unwrap();
+        .status()?;
+
     if !status.success() {
-         process::exit(status.code().unwrap_or(1));
+        anyhow::bail!("Process execution completed with exit code {:?}", status.code())
+    }
+
+    Ok(())
+}
+
+
+
+const USAGE: &str = r#"
+cargo-hfuzz
+
+Usage:
+  cargo-hfuzz (build|build-debug|build-no-instr|build-grcov) [(-v...|-q)] [<target>] [[--] <sub>...]
+  cargo-hfuzz (run|run-no-instr) [(-v...|-q)] [--iterations=<n>] [--timeout=<sec>] [--exit-upon-crash=<exitcode>] <target> [[--] <sub>...]
+  cargo-hfuzz (run-debug) [(-v...|-q)] <target> <crash_filename> [[--] <sub>...]
+  cargo-hfuzz clean [(-v...|-q)]
+  cargo-hfuzz (-h | --help | help)
+  cargo-hfuzz (--version | version)
+
+Options:
+  <target>                      The particular cargo target binary to use for fuzzing.
+  <crash_filename>              A particular crash dump to use for debuging.
+  <sub>...                      Additional arguments passed to the sub process.
+
+  -v --verbose                  Pass --verbose to honggfuzz, enable various log levels.
+  -q --quiet                    Silence.
+  --exit-upon-crash=<exitcode>  Exit upon the first crash with non-zero exit code.
+  -t --timeout=<sec>            Total time allowed to fuzz, in seconds.
+  -N --iterations=<n>           Total of fuzzing iterations to run.
+  -h --help                     Show this screen.
+  --version                     Show version.
+"#;
+
+
+#[derive(Debug, Deserialize, Clone)]
+pub(crate) struct Args {
+    flag_version: bool,
+    flag_help: bool,
+    cmd_version: bool, // backwards compat
+    cmd_help: bool,    // backwards compat
+    cmd_build_debug: bool,
+    cmd_build_no_instr: bool,
+    cmd_build: bool,
+    cmd_build_grcov: bool,
+    cmd_run_debug: bool,
+    cmd_run_no_instr: bool,
+    cmd_run: bool,
+    cmd_clean: bool,
+    flag_iterations: Option<u64>,
+    flag_timeout: Option<u64>,
+    flag_verbose: usize,
+    flag_quiet: bool,
+    flag_exit_upon_crash: Option<usize>,
+    arg_target: Option<String>,
+    arg_crash_filename: Option<String>,
+    // the remaining arguments
+    arg_sub: Vec<String>,
+}
+
+impl Args {
+    pub fn parse<S, I>(argv_iter: I) -> Result<Self, docopt::Error>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        const CARGO_HFUZZ: &str = "cargo-hfuzz";
+        const CARGO: &str = "cargo";
+        const HFUZZ: &str = "hfuzz";
+
+        Docopt::new(USAGE).and_then(|d| {
+            // if ends with file name CARGO_HFUZZ
+            let mut argv_iter = argv_iter.into_iter();
+            if let Some(arg0) = argv_iter.next() {
+                let arg0 = arg0.as_ref();
+                match PathBuf::from(arg0)
+                    .file_name()
+                    .map(|x| x.to_str())
+                    .flatten()
+                {
+                    Some(file_name) => {
+
+                        // allow all variants to be parsed
+                        // cargo hfuzz ...
+                        // cargo-hfuzz ...
+                        //
+                        // so preprocess them to unified `cargo-spellcheck`
+                        let mut next = vec![CARGO_HFUZZ.to_owned()];
+
+                        match argv_iter.next() {
+                            Some(arg) if file_name.starts_with(CARGO_HFUZZ) && arg.as_ref() == HFUZZ => {
+                                // drop the first arg HFUZZ`
+                            }
+                            Some(arg) if file_name.starts_with(CARGO) && arg.as_ref() == HFUZZ => {
+                                // drop it, we replace it with CARGO_HFUZZ
+                            }
+                            Some(arg) if arg.as_ref() == HFUZZ => {
+                                // HFUZZ but the binary got renamed
+                                // drop the HFUZZ part
+                            }
+                            Some(arg) => {
+                                // not HFUZZ so retain it
+                                next.push(arg.as_ref().to_owned())
+                            }
+                            None => {}
+                        };
+                        let collected = next.into_iter().chain(argv_iter.map(|s| s.as_ref().to_owned()));
+                        d.argv(collected)
+                    }
+                    _ => d,
+                }
+            } else {
+                d
+            }
+            .deserialize()
+        })
+    }
+
+    fn action(&self) -> Action {
+        if self.cmd_build {
+            Action::Build(BuildType::ReleaseInstrumented)
+        } else if self.cmd_build_no_instr {
+            Action::Build(BuildType::ReleaseNotInstrumented)
+        } else if self.cmd_build_debug {
+            Action::Build(BuildType::Debug)
+        } else if self.cmd_build_grcov {
+            Action::Build(BuildType::ProfileWithGrcov)
+        } else if self.cmd_run {
+            Action::Run(BuildType::ReleaseInstrumented)
+        } else if self.cmd_run_no_instr {
+            Action::Run(BuildType::ReleaseNotInstrumented)
+        } else if self.cmd_run_debug {
+            Action::Run(BuildType::Debug)
+        } else if self.cmd_version || self.flag_version {
+            Action::Version
+        } else if self.cmd_clean {
+            Action::Clean
+        } else {
+            Action::Help
+        }
+    }
+
+    fn verbosity(&self) -> log::LevelFilter {
+        match self.flag_verbose {
+            _ if self.flag_quiet => log::LevelFilter::Off,
+            2 => log::LevelFilter::Warn,
+            3 => log::LevelFilter::Info,
+            4 => log::LevelFilter::Debug,
+            n if n > 4 => log::LevelFilter::Trace,
+            _ => log::LevelFilter::Error,
+        }
     }
 }
 
-fn main() {
-    // TODO: maybe use `clap` crate
+#[derive(Debug, Copy, Clone)]
+enum Action {
+    Build(BuildType),
+    Run(BuildType),
+    Version,
+    Clean,
+    Help,
+}
 
-    let mut args = env::args().skip(1);
-    if args.next() != Some("hfuzz".to_string()) {
-        eprintln!("please launch as a cargo subcommand: \"cargo hfuzz ...\"");
-        process::exit(1);
-    }
+fn main() -> Result<()> {
+    let args = Args::parse(env::args())?;
+    pretty_env_logger::formatted_timed_builder()
+        .filter_level(args.verbosity())
+        .init();
 
     // change to crate root to have the same behavior as cargo build/run
-    let crate_root = find_crate_root().unwrap_or_else(|| {
-        eprintln!("error: could not find `Cargo.toml` in current directory or any parent directory");
-        process::exit(1);
-    });
+    let crate_root = find_crate_root().map_err(|e| {
+        e.context(anyhow::anyhow!("could not find `Cargo.toml` in current directory or any parent directory"))
+    })?;
     env::set_current_dir(&crate_root).unwrap();
 
-    match args.next() {
-        Some(ref s) if s == "build" => {
-            hfuzz_build(args, &crate_root, &BuildType::ReleaseInstrumented);
-        }
-        Some(ref s) if s == "build-no-instr" => {
-            hfuzz_build(args, &crate_root, &BuildType::ReleaseNotInstrumented);
-        }
-        Some(ref s) if s == "build-debug" => {
-            hfuzz_build(args, &crate_root, &BuildType::Debug);
-        }
-        Some(ref s) if s == "build-grcov" => {
-            hfuzz_build(args, &crate_root, &BuildType::ProfileWithGrcov);
-        }
-        Some(ref s) if s == "run" => {
-            hfuzz_run(args, &crate_root, &BuildType::ReleaseInstrumented);
-        }
-        Some(ref s) if s == "run-no-instr" => {
-            hfuzz_run(args, &crate_root, &BuildType::ReleaseNotInstrumented);
+    match args.action() {
+        Action::Build(ty) => hfuzz_build(args, &crate_root, ty)?,
+        Action::Run(ty) => hfuzz_run(args, &crate_root, ty)?,
+        Action::Clean => hfuzz_clean(args)?,
+        Action::Version => hfuzz_version(),
+        Action::Help => println!("{}", USAGE),
+    };
+    Ok(())
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assert_matches::assert_matches;
+
+    #[test]
+    fn args() {
+        fn check(cl: &'static str) -> Args {
+            let args = Args::parse(
+                cl.split_ascii_whitespace()
+            ).expect("Must parse. qed ");
+            args
         }
 
-        Some(ref s) if s == "run-debug" => {
-            hfuzz_run(args, &crate_root, &BuildType::Debug);
-        }
-        Some(ref s) if s == "clean" => {
-            hfuzz_clean(args);
-        }
-        Some(ref s) if s == "version" => {
-            hfuzz_version();
-        }
-        _ => {
-            eprintln!("possible commands are: run, run-no-instr, run-debug, build, build-no-instr, build-grcov, build-debug, clean, version");
-            process::exit(1);
-        }
+
+        assert_matches!(
+            check("cargo hfuzz run -vvv some-binary --exit-upon-crash=77 -- fff --xyz"),
+            Args {
+                cmd_run,
+                flag_verbose,
+                arg_target,
+                flag_exit_upon_crash,
+                arg_sub,
+                ..
+            } => {
+                assert!(cmd_run);
+                assert_eq!(flag_verbose, 3);
+                assert_eq!(arg_target, Some("some-binary".to_owned()));
+                assert_eq!(flag_exit_upon_crash, Some(77));
+                assert_eq!(arg_sub.as_slice(), &["fff", "--xyz"]);
+            });
+
+
+        assert_matches!(
+            check("cargo hfuzz run -q foo --exit-upon-crash=0 -- --xyz"),
+            Args {
+                cmd_run,
+                flag_verbose,
+                flag_quiet,
+                arg_target,
+                flag_exit_upon_crash,
+                arg_sub,
+                ..
+            } => {
+                assert!(cmd_run);
+                assert_eq!(flag_verbose, 0);
+                assert!(flag_quiet);
+                assert_eq!(arg_target, Some("foo".to_owned()));
+                assert_eq!(flag_exit_upon_crash, Some(0));
+                assert_eq!(arg_sub.as_slice(), ["--xyz"]);
+            });
     }
 }

--- a/src/bin/cargo-hfuzz.rs
+++ b/src/bin/cargo-hfuzz.rs
@@ -1,4 +1,4 @@
-use std::fs;
+use fs_err as fs;
 use std::env;
 use std::process::{self, Command};
 use std::os::unix::process::CommandExt;

--- a/src/bin/cargo-hfuzz.rs
+++ b/src/bin/cargo-hfuzz.rs
@@ -11,7 +11,7 @@ const HONGGFUZZ_WORKSPACE: &str = "hfuzz_workspace";
 #[cfg(target_family="windows")]
 compile_error!("honggfuzz-rs does not currently support Windows but works well under WSL (Windows Subsystem for Linux)");
 
-#[derive(PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum BuildType {
     ReleaseInstrumented,
     ReleaseNotInstrumented,
@@ -25,18 +25,18 @@ fn target_triple() -> String {
     rustc_version::version_meta().expect("RUSTC version data is available. qed").host
 }
 
-fn find_crate_root() -> Option<PathBuf> {
-    let mut path = env::current_dir().unwrap();
-
+fn find_crate_root() -> Result<PathBuf> {
+    let path = env::current_dir()
+        .map_err(|e| anyhow::anyhow!("Current directory is not set for process.").context(e))?;
+    let mut path = path.as_path();
     while !path.join("Cargo.toml").is_file() {
         // move to parent path
-        path = match path.parent() {
-            Some(parent) => parent.into(),
-            None => return None, // early return
-        };
+        path = path
+            .parent()
+            .ok_or_else(|| anyhow::anyhow!("Reached root without finding Cargo.toml"))?;
     }
 
-    Some(path)
+    Ok(path.to_path_buf())
 }
 
 fn debugger_command(target: &str, triple: &str) -> Command {
@@ -65,11 +65,11 @@ fn hfuzz_version() {
     println!("cargo-hfuzz {}", VERSION);
 }
 
-fn hfuzz_run<T>(mut args: T, crate_root: &Path, build_type: &BuildType) where T: std::iter::Iterator<Item=String> {
-    let target = args.next().unwrap_or_else(||{
-        eprintln!("please specify the name of the target like this \"cargo hfuzz run[-debug|-no-instr] TARGET [ ARGS ... ]\"");
-        process::exit(1);
-    });
+fn hfuzz_run(args: Args, crate_root: &Path, build_type: BuildType) -> Result<()> {
+    let target = args
+        .arg_target
+        .as_ref()
+        .expect("Docopt USAGE meta definition guarantees target is set. qed");
 
     let honggfuzz_target = env::var("CARGO_TARGET_DIR").unwrap_or_else(|_| HONGGFUZZ_TARGET.into());
     let honggfuzz_workspace = env::var("HFUZZ_WORKSPACE").unwrap_or_else(|_| HONGGFUZZ_WORKSPACE.into());
@@ -98,13 +98,14 @@ fn hfuzz_run<T>(mut args: T, crate_root: &Path, build_type: &BuildType) where T:
         _ => {
             // add some flags to sanitizers to make them work with Rust code
             let asan_options = env::var("ASAN_OPTIONS").unwrap_or_default();
-            let asan_options = format!("detect_odr_violation=0:{}", asan_options);
+            let asan_options = "detect_odr_violation=0:".to_owned() + asan_options.as_str();
 
             let tsan_options = env::var("TSAN_OPTIONS").unwrap_or_default();
-            let tsan_options = format!("report_signal_unsafe=0:{}", tsan_options);
+            let tsan_options = "report_signal_unsafe=0:".to_owned() + tsan_options.as_str();
 
             // get user-defined args for honggfuzz
             let hfuzz_run_args = env::var("HFUZZ_RUN_ARGS").unwrap_or_default();
+
             // FIXME: we split by whitespace without respecting escaping or quotes
             let hfuzz_run_args = hfuzz_run_args.split_whitespace();
 
@@ -132,19 +133,6 @@ fn hfuzz_run<T>(mut args: T, crate_root: &Path, build_type: &BuildType) where T:
 fn hfuzz_build<T>(args: T, crate_root: &Path, build_type: &BuildType) where T: std::iter::Iterator<Item=String> {
     let honggfuzz_target = env::var("CARGO_TARGET_DIR").unwrap_or_else(|_| HONGGFUZZ_TARGET.into());
 
-    // HACK: temporary fix, see https://github.com/rust-lang/rust/issues/53945#issuecomment-426824324
-    let use_gold_linker: bool = match Command::new("which") // check if the gold linker is available
-            .args(&["ld.gold"])
-            .status() {
-        Err(_) => false,
-        Ok(status) => {
-            match status.code() {
-                Some(0) => true,
-                _       => false
-            }
-        }
-    };
-
     let mut rustflags = "\
     --cfg fuzzing \
     -C debug-assertions \
@@ -152,7 +140,7 @@ fn hfuzz_build<T>(args: T, crate_root: &Path, build_type: &BuildType) where T: s
     ".to_string();
 
     let mut cargo_incremental = "1";
-    match *build_type {
+    match build_type {
         BuildType::Debug => {
             rustflags.push_str("\
             --cfg fuzzing_debug \
@@ -183,7 +171,7 @@ fn hfuzz_build<T>(args: T, crate_root: &Path, build_type: &BuildType) where T: s
             -C debuginfo=0 \
             ");
 
-            if *build_type == BuildType::ReleaseInstrumented {
+            if build_type == BuildType::ReleaseInstrumented {
                 rustflags.push_str("\
                 -C passes=sancov \
                 -C llvm-args=-sanitizer-coverage-level=4 \
@@ -199,7 +187,8 @@ fn hfuzz_build<T>(args: T, crate_root: &Path, build_type: &BuildType) where T: s
                 }
 
                 // HACK: temporary fix, see https://github.com/rust-lang/rust/issues/53945#issuecomment-426824324
-                if use_gold_linker {
+                // HACK: check if the gold linker is available
+                if which::which("ld.gold").is_ok() {
                     rustflags.push_str("-Clink-arg=-fuse-ld=gold ");
                 }
             }


### PR DESCRIPTION
…ructure

This remedies _some_ of the internal TODOs and yields better error messages.

Motivation is, to allow additional verifyable arguments to enhance practical usability without having to re-read various help texts on which param gets passed to which process.