### PR TITLE
fix(build): fix hfuzz_build_args parsing

### DIFF
--- a/src/bin/cargo-hfuzz.rs
+++ b/src/bin/cargo-hfuzz.rs
@@ -333,7 +333,7 @@ where
     else if *build_type != BuildType::Debug {
         // ensure we do not set --release when one of the build args
         // contains a --profile
-        if !hfuzz_build_args.any(|f| &f[..9] == "--profile") {
+        if !hfuzz_build_args.any(|f| f.starts_with("--profile")) {
             command.arg("--release");
         }
 


### PR DESCRIPTION
The code searches hfuzz_build_args for any tokens matching "--profile", but it currently does this in a way that fails if any of the contained tokens are shorter than 9 characters. Simplify the check.