### PR TITLE
Format with rustfmt

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,7 +23,7 @@ jobs:
       run: sudo apt-get install --no-install-recommends build-essential binutils-dev libunwind-dev libblocksruntime-dev liblzma-dev
     - name: Test
       run: ./test.sh
-  
+
 #  ubuntu-beta:
 #    runs-on: ubuntu-24.04
 #    steps:
@@ -37,7 +37,7 @@ jobs:
 #      run: sudo apt-get install --no-install-recommends build-essential binutils-dev libunwind-dev libblocksruntime-dev liblzma-dev
 #    - name: Test
 #      run: ./test.sh
-      
+
   ubuntu-stable:
     runs-on: ubuntu-24.04
     steps:

--- a/build.rs
+++ b/build.rs
@@ -5,24 +5,37 @@ use std::process::{self, Command};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
-#[cfg(target_family="windows")]
+#[cfg(target_family = "windows")]
 compile_error!("honggfuzz-rs does not currently support Windows but works well under WSL (Windows Subsystem for Linux)");
 
 // TODO: maybe use `make-cmd` crate
-#[cfg(not(any(target_os = "freebsd", target_os = "dragonfly", target_os = "bitrig", target_os = "openbsd", target_os = "netbsd")))]
+#[cfg(not(any(
+    target_os = "freebsd",
+    target_os = "dragonfly",
+    target_os = "bitrig",
+    target_os = "openbsd",
+    target_os = "netbsd"
+)))]
 const GNU_MAKE: &str = "make";
-#[cfg(any(target_os = "freebsd", target_os = "dragonfly", target_os = "bitrig", target_os = "openbsd", target_os = "netbsd"))]
+#[cfg(any(
+    target_os = "freebsd",
+    target_os = "dragonfly",
+    target_os = "bitrig",
+    target_os = "openbsd",
+    target_os = "netbsd"
+))]
 const GNU_MAKE: &str = "gmake";
 
 fn main() {
     // Only build honggfuzz binaries if we are in the process of building an instrumentized binary
     let honggfuzz_target = match env::var("CARGO_HONGGFUZZ_TARGET_DIR") {
         Ok(path) => path, // path where to place honggfuzz binary. provided by cargo-hfuzz command.
-        Err(_) => return
+        Err(_) => return,
     };
 
     // check that "cargo hfuzz" command is at the same version as this file
-    let honggfuzz_build_version = env::var("CARGO_HONGGFUZZ_BUILD_VERSION").unwrap_or("unknown".to_string());
+    let honggfuzz_build_version =
+        env::var("CARGO_HONGGFUZZ_BUILD_VERSION").unwrap_or("unknown".to_string());
     if VERSION != honggfuzz_build_version {
         eprintln!("The version of the honggfuzz library dependency ({0}) and the version of the `cargo-hfuzz` executable ({1}) do not match.\n\
                    If updating both by running `cargo update` and `cargo install honggfuzz` does not work, you can either:\n\
@@ -52,7 +65,11 @@ fn main() {
     assert!(status.success());
 
     fs::copy("honggfuzz/libhfuzz/libhfuzz.a", out_dir.join("libhfuzz.a")).unwrap();
-    fs::copy("honggfuzz/libhfcommon/libhfcommon.a", out_dir.join("libhfcommon.a")).unwrap();
+    fs::copy(
+        "honggfuzz/libhfcommon/libhfcommon.a",
+        out_dir.join("libhfcommon.a"),
+    )
+    .unwrap();
     fs::copy("honggfuzz/honggfuzz", honggfuzz_target.join("honggfuzz")).unwrap();
 
     // tell cargo how to link final executable to hfuzz static library

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -1,7 +1,7 @@
 use honggfuzz::fuzz;
 
 fn main() {
-    // Here you can parse `std::env::args and 
+    // Here you can parse `std::env::args and
     // setup / initialize your project
 
     // You should avoid as much as possible global states.
@@ -28,7 +28,7 @@ fn main() {
             if data[2] != b'y' {return}
             panic!("BOOM")
         });
-            
+
         // The fuzz macro gives an arbitrary object (see `arbitrary crate`)
         // to a closure-like block of code if you set the `arbitrary` feature.
         // Here, this tuple will contain two "random" values of different type.

--- a/example/test.sh
+++ b/example/test.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -vex
 export RUST_BACKTRACE=full
 
-CARGO_HFUZZ=${CARGO_HFUZZ:-"cargo hfuzz"} # by default, use regular subcommand. Override to force using another version (for tests) 
+CARGO_HFUZZ=${CARGO_HFUZZ:-"cargo hfuzz"} # by default, use regular subcommand. Override to force using another version (for tests)
 
 cargo clean
 

--- a/src/bin/cargo-hfuzz.rs
+++ b/src/bin/cargo-hfuzz.rs
@@ -279,7 +279,7 @@ where
                     -C passes=sancov \
                     ");
                 };
-                
+
                 rustflags.push_str(
                     "\
                 -C llvm-args=-sanitizer-coverage-level=4 \

--- a/src/bin/cargo-hfuzz.rs
+++ b/src/bin/cargo-hfuzz.rs
@@ -208,15 +208,14 @@ where
 
     // HACK: temporary fix, see https://github.com/rust-lang/rust/issues/53945#issuecomment-426824324
     let use_gold_linker: bool = match Command::new("which") // check if the gold linker is available
-            .args(&["ld.gold"])
-            .status() {
+        .args(&["ld.gold"])
+        .status()
+    {
         Err(_) => false,
-        Ok(status) => {
-            match status.code() {
-                Some(0) => true,
-                _       => false
-            }
-        }
+        Ok(status) => match status.code() {
+            Some(0) => true,
+            _ => false,
+        },
     };
 
     let mut rustflags = "\
@@ -271,13 +270,17 @@ where
                 // compilers for which the LLVM version is >= 13.
                 let version_meta = rustc_version::version_meta().unwrap();
                 if version_meta.llvm_version.map_or(true, |v| v.major >= 13) {
-                    rustflags.push_str("\
+                    rustflags.push_str(
+                        "\
                     -C passes=sancov-module \
-                    ");
+                    ",
+                    );
                 } else {
-                    rustflags.push_str("\
+                    rustflags.push_str(
+                        "\
                     -C passes=sancov \
-                    ");
+                    ",
+                    );
                 };
 
                 rustflags.push_str(

--- a/src/bin/cargo-honggfuzz.rs
+++ b/src/bin/cargo-honggfuzz.rs
@@ -1,10 +1,10 @@
 use std::env;
-use std::process::{self, Command};
 use std::os::unix::process::CommandExt;
+use std::process::{self, Command};
 
 const HONGGFUZZ_TARGET: &str = "hfuzz_target";
 
-#[cfg(target_family="windows")]
+#[cfg(target_family = "windows")]
 compile_error!("honggfuzz-rs does not currently support Windows but works well under WSL (Windows Subsystem for Linux)");
 
 fn main() {
@@ -29,6 +29,9 @@ fn main() {
         .exec();
 
     // code flow will only reach here if honggfuzz failed to execute
-    eprintln!("cannot execute {}, try to execute \"cargo hfuzz build\" from fuzzed project directory", &command);
+    eprintln!(
+        "cannot execute {}, try to execute \"cargo hfuzz build\" from fuzzed project directory",
+        &command,
+    );
     process::exit(1);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,60 +1,60 @@
 //! ## About Honggfuzz
-//! 
+//!
 //! Honggfuzz is a security oriented fuzzer with powerful analysis options. Supports evolutionary, feedback-driven fuzzing based on code coverage (software- and hardware-based).
-//! 
+//!
 //! * project homepage [honggfuzz.com](http://honggfuzz.com/)
 //! * project repository [github.com/google/honggfuzz](https://github.com/google/honggfuzz)
 //! * this upstream project is maintained by Google, but ...
 //! * this is NOT an official Google product
-//! 
+//!
 //! ## Compatibility
-//! 
+//!
 //! * __Rust__: stable, beta, nightly
 //! * __OS__: GNU/Linux, macOS, FreeBSD, NetBSD, Android, WSL (Windows Subsystem for Linux)
 //! * __Arch__: x86_64, x86, arm64-v8a, armeabi-v7a, armeabi
-//! * __Sanitizer__: none, address, thread, leak 
-//! 
+//! * __Sanitizer__: none, address, thread, leak
+//!
 //! ## Dependencies
-//! 
+//!
 //! ### Linux
-//! 
+//!
 //! * C compiler: `cc`
 //! * GNU Make: `make`
 //! * GNU Binutils development files for the BFD library: `libbfd.h`
 //! * libunwind development files: `libunwind.h`
 //! * liblzma development files
-//! 
+//!
 //! For example on Debian and its derivatives:
-//! 
+//!
 //! ```sh
 //! sudo apt install build-essential binutils-dev libunwind-dev
 //! ```
-//! 
+//!
 //! ## How to use this crate
-//! 
+//!
 //! Install honggfuzz commands to build with instrumentation and fuzz
-//! 
+//!
 //! ```sh
 //! # installs hfuzz and honggfuzz subcommands in cargo
 //! cargo install honggfuzz
 //! ```
-//! 
+//!
 //! Add to your dependencies
-//! 
+//!
 //! ```toml
 //! [dependencies]
 //! honggfuzz = "0.5"
 //! ```
-//! 
+//!
 //! Create a target to fuzz
-//! 
+//!
 //! ```rust,should_panic
 //! use honggfuzz::fuzz;
-//! 
+//!
 //! fn main() {
-//!     // Here you can parse `std::env::args and 
+//!     // Here you can parse `std::env::args and
 //!     // setup / initialize your project
-//! 
+//!
 //!     // You have full control over the loop but
 //!     // you're supposed to call `fuzz` ad vitam aeternam
 //!     loop {
@@ -72,69 +72,69 @@
 //!         });
 //!     }
 //! }
-//! 
+//!
 //! ```
-//! 
+//!
 //! Fuzz for fun and profit !
-//! 
+//!
 //! ```sh
 //! # builds with fuzzing instrumentation and then fuzz the "example" target
 //! cargo hfuzz run example
 //! ```
-//! 
+//!
 //! Once you got a crash, replay it easily in a debug environment
-//! 
+//!
 //! ```sh
 //! # builds the target in debug mode and replays automatically the crash in gdb
 //! cargo hfuzz run-debug example fuzzing_workspace/*.fuzz
 //! ```
-//! 
+//!
 //! You can also build and run your project without compile-time software instrumentation (LLVM's SanCov passes)
-//! 
+//!
 //! This allows you for example to try hardware-only feedback driven fuzzing:
-//! 
+//!
 //! ```sh
 //! # builds without fuzzing instrumentation and then fuzz the "example" target using hardware-based feedback
 //! HFUZZ_RUN_ARGS="--linux_perf_ipt_block --linux_perf_instr --linux_perf_branch" cargo hfuzz run-no-instr example
 //! ```
-//! 
+//!
 //! Clean
-//! 
+//!
 //! ```sh
 //! # a wrapper on "cargo clean" which cleans the fuzzing_target directory
-//! cargo hfuzz clean 
+//! cargo hfuzz clean
 //! ```
-//! 
+//!
 //! Version
-//! 
+//!
 //! ```sh
 //! cargo hfuzz version
 //! ```
-//! 
+//!
 //! ### Environment variables
-//! 
+//!
 //! #### `RUSTFLAGS`
-//! 
+//!
 //! You can use `RUSTFLAGS` to send additional arguments to `rustc`.
-//! 
+//!
 //! For instance, you can enable the use of LLVM's [sanitizers](https://github.com/japaric/rust-san).
 //! This is a recommended option if you want to test your `unsafe` rust code but it will have an impact on performance.
-//! 
+//!
 //! ```sh
 //! RUSTFLAGS="-Z sanitizer=address" cargo hfuzz run example
 //! ```
-//! 
+//!
 //! #### `HFUZZ_BUILD_ARGS`
-//! 
+//!
 //! You can use `HFUZZ_BUILD_ARGS` to send additional arguments to `cargo build`.
-//! 
+//!
 //! #### `HFUZZ_RUN_ARGS`
-//! 
+//!
 //! You can use `HFUZZ_RUN_ARGS` to send additional arguments to `honggfuzz`.
 //! See [USAGE](https://github.com/google/honggfuzz/blob/master/docs/USAGE.md) for the list of those.
-//! 
+//!
 //! For example:
-//! 
+//!
 //! ```sh
 //! # 1 second of timeout
 //! # use 12 fuzzing thread
@@ -143,27 +143,27 @@
 //! # exit upon crash
 //! HFUZZ_RUN_ARGS="-t 1 -n 12 -v -N 1000000 --exit_upon_crash" cargo hfuzz run example
 //! ```
-//! 
+//!
 //! #### `HFUZZ_DEBUGGER`
-//! 
+//!
 //! By default we use `rust-lldb` but you can change it to `rust-gdb`, `gdb`, `/usr/bin/lldb-7` ...
-//! 
+//!
 //! #### `CARGO_TARGET_DIR`
-//! 
+//!
 //! Target compilation directory, defaults to `hfuzz_target` to not clash with `cargo build`'s default `target` directory.
-//! 
+//!
 //! #### `HFUZZ_WORKSPACE`
-//! 
+//!
 //! Honggfuzz working directory, defaults to `hfuzz_workspace`.
-//! 
+//!
 //! #### `HFUZZ_INPUT`
-//! 
+//!
 //! Honggfuzz input files (also called "corpus"), defaults to `$HFUZZ_WORKSPACE/{TARGET}/input`.
-//! 
+//!
 //! ## Conditional compilation
-//! 
+//!
 //! Sometimes, it is necessary to make some specific adaptation to your code to yield a better fuzzing efficiency.
-//! 
+//!
 //! For instance:
 //! - Make you software behavior as much as possible deterministic on the fuzzing input
 //!   - [PRNG](https://en.wikipedia.org/wiki/Pseudorandom_number_generator)s must be seeded with a constant or the fuzzer input
@@ -173,10 +173,10 @@
 //! - Never ever call `std::process::exit()`.
 //! - Disable logging and other unnecessary functionalities.
 //! - Try to avoid modifying global state when possible.
-//! 
-//! 
+//!
+//!
 //! When building with `cargo hfuzz`, the argument `--cfg fuzzing` is passed to `rustc` to allow you to condition the compilation of those adaptations thanks to the `cfg` macro like so:
-//! 
+//!
 //! ```rust
 //! # use rand::{self, Rng, SeedableRng};
 //! # use rand_chacha;
@@ -187,22 +187,22 @@
 //! let mut rng = rand::thread_rng();
 //! # }
 //! ```
-//! 
+//!
 //! Also, when building in debug mode, the `fuzzing_debug` argument is added in addition to `fuzzing`.
-//! 
+//!
 //! For more information about conditional compilation, please see the [reference](https://doc.rust-lang.org/reference/attributes.html#conditional-compilation).
-//! 
+//!
 //! ## Relevant documentation about honggfuzz
 //! * [USAGE](https://github.com/google/honggfuzz/blob/master/docs/USAGE.md)
 //! * [FeedbackDrivenFuzzing](https://github.com/google/honggfuzz/blob/master/docs/FeedbackDrivenFuzzing.md)
 //! * [PersistentFuzzing](https://github.com/google/honggfuzz/blob/master/docs/PersistentFuzzing.md)
-//! 
+//!
 //! ## About Rust fuzzing
-//!  
-//! There is other projects providing Rust fuzzing support at [github.com/rust-fuzz](https://github.com/rust-fuzz). 
-//!  
+//!
+//! There is other projects providing Rust fuzzing support at [github.com/rust-fuzz](https://github.com/rust-fuzz).
+//!
 //! You'll find support for [AFL](https://github.com/rust-fuzz/afl.rs) and LLVM's [LibFuzzer](https://github.com/rust-fuzz/cargo-fuzz) and there is also a [trophy case](https://github.com/rust-fuzz/trophy-case) ;-) .
-//! 
+//!
 //! This crate was inspired by those projects!
 
 /// Re-export of arbitrary crate used to generate structured inputs
@@ -298,7 +298,7 @@ pub fn fuzz<F>(closure: F) where F: FnOnce(&[u8]) {
     use std::env;
     use std::fs::File;
     use memmap2::MmapOptions;
-    
+
     let filename = env::var("CARGO_HONGGFUZZ_CRASH_FILENAME").unwrap_or_else(|_|{
         eprintln!("error: Environment variable CARGO_HONGGFUZZ_CRASH_FILENAME not set. Try launching with \"cargo hfuzz run-debug TARGET CRASH_FILENAME [ ARGS ... ]\"");
         std::process::exit(1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,7 +211,7 @@ pub use arbitrary;
 
 #[cfg(all(fuzzing, not(fuzzing_debug)))]
 extern "C" {
-    fn HF_ITER(buf_ptr: *mut *const u8, len_ptr: *mut usize );
+    fn HF_ITER(buf_ptr: *mut *const u8, len_ptr: *mut usize);
 }
 
 /// Fuzz a closure by passing it a `&[u8]`
@@ -239,7 +239,10 @@ extern "C" {
 /// ```
 #[cfg(not(fuzzing))]
 #[allow(unused_variables)]
-pub fn fuzz<F>(closure: F) where F: FnOnce(&[u8]) {
+pub fn fuzz<F>(closure: F)
+where
+    F: FnOnce(&[u8]),
+{
     eprintln!("This executable hasn't been built with \"cargo hfuzz\".");
     eprintln!("Try executing \"cargo hfuzz build\" and check out \"hfuzz_target\" directory.");
     eprintln!("Or execute \"cargo hfuzz run TARGET\"");
@@ -259,7 +262,10 @@ lazy_static::lazy_static! {
 }
 
 #[cfg(all(fuzzing, not(fuzzing_debug)))]
-pub fn fuzz<F>(closure: F) where F: FnOnce(&[u8]) {
+pub fn fuzz<F>(closure: F)
+where
+    F: FnOnce(&[u8]),
+{
     use std::mem::MaybeUninit;
 
     // sets panic hook if not already done
@@ -284,7 +290,8 @@ pub fn fuzz<F>(closure: F) where F: FnOnce(&[u8]) {
     // [`std::panic::UnwindSafe`] trait.
     let did_panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         closure(buf);
-    })).is_err();
+    }))
+    .is_err();
 
     if did_panic {
         // hopefully the custom panic hook will be called before and abort the
@@ -294,22 +301,25 @@ pub fn fuzz<F>(closure: F) where F: FnOnce(&[u8]) {
 }
 
 #[cfg(all(fuzzing, fuzzing_debug))]
-pub fn fuzz<F>(closure: F) where F: FnOnce(&[u8]) {
+pub fn fuzz<F>(closure: F)
+where
+    F: FnOnce(&[u8]),
+{
+    use memmap2::MmapOptions;
     use std::env;
     use std::fs::File;
-    use memmap2::MmapOptions;
 
     let filename = env::var("CARGO_HONGGFUZZ_CRASH_FILENAME").unwrap_or_else(|_|{
         eprintln!("error: Environment variable CARGO_HONGGFUZZ_CRASH_FILENAME not set. Try launching with \"cargo hfuzz run-debug TARGET CRASH_FILENAME [ ARGS ... ]\"");
         std::process::exit(1);
     });
 
-    let file = File::open(&filename).unwrap_or_else(|_|{
+    let file = File::open(&filename).unwrap_or_else(|_| {
         eprintln!("error: failed to open \"{}\"", &filename);
         std::process::exit(1);
     });
 
-    let mmap = unsafe {MmapOptions::new().map(&file)}.unwrap_or_else(|_|{
+    let mmap = unsafe { MmapOptions::new().map(&file) }.unwrap_or_else(|_| {
         eprintln!("error: failed to mmap file \"{}\"", &filename);
         std::process::exit(1);
     });
@@ -334,7 +344,7 @@ macro_rules! _arbitrary_fuzz {
                 if let Ok(buf) = Arbitrary::arbitrary(&mut buf) {
                     buf
                 } else {
-                    return
+                    return;
                 }
             };
 
@@ -379,4 +389,3 @@ macro_rules! fuzz {
         $crate::_arbitrary_fuzz!(|$buf: $dty| $body);
     };
 }
-


### PR DESCRIPTION
While working on a different PR, it was disruptive to not be able to rely on rustfmt to format my changes due to idiosyncratic formatting throughout the existing code.