### PR TITLE
Hide output of `which` command

### DIFF
--- a/src/bin/cargo-hfuzz.rs
+++ b/src/bin/cargo-hfuzz.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::fs;
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
-use std::process::{self, Command};
+use std::process::{self, Command, Stdio};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 const HONGGFUZZ_TARGET: &str = "hfuzz_target";
@@ -209,6 +209,9 @@ where
     // HACK: temporary fix, see https://github.com/rust-lang/rust/issues/53945#issuecomment-426824324
     let use_gold_linker: bool = match Command::new("which") // check if the gold linker is available
         .args(&["ld.gold"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .stdin(Stdio::null())
         .status()
     {
         Err(_) => false,


### PR DESCRIPTION
Without this, every `cargo hfuzz` command on my machine starts by printing "/usr/bin/ld.gold" to stdout on the first line, which is confusing and unnecessary.

```console
$ cargo hfuzz build --no-default-features --features honggfuzz
/usr/bin/ld.gold
   Compiling semver v1.0.26
   Compiling proc-macro2 v1.0.94
   Compiling honggfuzz v0.5.56
   Compiling unicode-ident v1.0.18
   Compiling lazy_static v1.5.0
   Compiling arbitrary v1.4.1
   Compiling rustc_version v0.4.1
    Finished `release` profile [optimized] target(s) in 3.42s
```