### PR TITLE
Unforce gold linker on recent toolchains

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "rustc_version",
+ "semver",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ default = ["arbitrary"]
 [dependencies]
 arbitrary = { version = "1", optional = true }
 rustc_version = "0.4"
+semver = "1"
 
 [dev-dependencies]
 rand = "0.8"


### PR DESCRIPTION
Fixes #97.

Similar to https://github.com/rust-fuzz/afl.rs/pull/597, but without breaking older rustc.