### PR TITLE
feat: support standalone mode (read from file/stdin)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,7 @@ version = "0.5.58"
 dependencies = [
  "arbitrary",
  "lazy_static",
+ "libc",
  "memmap2",
  "rand",
  "rand_chacha",
@@ -47,9 +48,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.176"
+version = "0.2.178"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
+checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
 name = "memmap2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ default = ["arbitrary"]
 
 [dependencies]
 arbitrary = { version = "1", optional = true }
+libc = "0.2"
 rustc_version = "0.4"
 semver = "1"
 
@@ -43,3 +44,6 @@ lazy_static = "1.5"
 
 [target.'cfg(fuzzing_debug)'.dependencies]
 memmap2 = "0.9"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)', 'cfg(fuzzing_debug)'] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,6 +249,53 @@ where
     std::process::exit(17);
 }
 
+// This is the magic file descriptor honggfuzz uses
+// https://github.com/google/honggfuzz/blob/8baf395e52a5d5dbb9f16642ad3be419fa6c58cb/honggfuzz.h#L89-L90
+const HF_INPUT_FD: std::os::unix::io::RawFd = 1021;
+
+fn is_input_available() -> bool {
+    unsafe {
+        let result = libc::fcntl(HF_INPUT_FD, libc::F_GETFD);
+        // https://github.com/google/honggfuzz/blob/8baf395e52a5d5dbb9f16642ad3be419fa6c58cb/libhfuzz/fetch.c#L23-L24
+        if result == -1 && *libc::__errno_location() == libc::EBADF {
+            false // Honggfuzz persistent mode
+        } else {
+            true // Read from file or stdin
+        }
+    }
+}
+
+fn run_from_file<F>(closure: F) -> i32
+where
+    F: FnOnce(&[u8]),
+{
+    let args: Vec<String> = std::env::args().collect();
+
+    let input = if args.len() > 1 {
+        match std::fs::read(&args[args.len() - 1]) {
+            Ok(data) => data,
+            Err(e) => {
+                eprintln!("Cannot open '{}': {}", args[args.len() - 1], e);
+                return 1;
+            }
+        }
+    } else {
+        read_stdin()
+    };
+
+    closure(&input);
+    0
+}
+
+fn read_stdin() -> Vec<u8> {
+    use std::io::Read;
+    let mut buf = Vec::new();
+    std::io::stdin()
+        .read_to_end(&mut buf)
+        .expect("Failed to read stdin");
+    buf
+}
+
 // Registers a panic hook that aborts the process before unwinding.
 // It is useful to abort before unwinding so that the fuzzer will then be
 // able to analyse the process stack frames to tell different bugs apart.
@@ -271,15 +318,22 @@ where
     // sets panic hook if not already done
     lazy_static::initialize(&PANIC_HOOK);
 
-    // get buffer from honggfuzz runtime
-    let buf;
+    // Relicating logic from: https://github.com/google/honggfuzz/blob/8baf395e52a5d5dbb9f16642ad3be419fa6c58cb/libhfuzz/persistent.c#L117-L121
+    // Check if running in persistent mode
+    if !is_input_available() {
+        // Running standalone - read input from file/stdin and run once
+        std::process::exit(run_from_file(closure));
+    }
 
+    // Persistent loop
+    let buf;
     let mut buf_ptr = MaybeUninit::<*const u8>::uninit();
     let mut len_ptr = MaybeUninit::<usize>::uninit();
 
     unsafe {
+        // Get buffer from honggfuzz runtime
         HF_ITER(buf_ptr.as_mut_ptr(), len_ptr.as_mut_ptr());
-        buf = ::std::slice::from_raw_parts(buf_ptr.assume_init(), len_ptr.assume_init());
+        buf = std::slice::from_raw_parts(buf_ptr.assume_init(), len_ptr.assume_init());
     }
 
     // We still catch unwinding panics just in case the fuzzed code modifies


### PR DESCRIPTION
This PR replicates detecting whether the honggfuzz runtime is driving the binary in persistent mode or the input is being delivered via a file/stdin. This allow reproducing crashes without recompiling or being automatically dropped into GDB.

See honggfuzz reference: https://github.com/google/honggfuzz/blob/8baf395e52a5d5dbb9f16642ad3be419fa6c58cb/libhfuzz/persistent.c#L117-L121